### PR TITLE
feat: environment variables support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         AmplifyAppId: ${{ secrets.AMPLIFYAPPID }}
         BackendEnvARN: ${{ secrets.BACKENDENVARN }}
+        EnvironmentVariables: 'key1=value,key2=value'
         AWS_REGION: 'us-east-1'
 ```
 
@@ -59,6 +60,7 @@ The following settings must be passed as environment variables as shown in the e
 | `AWS_REGION` | The region where you created your bucket. Set to `us-east-1` by default. [Full list of regions here.](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) | `env` | **Yes** | `us-east-1` |
 | `AmplifyAppId` | The unique ID for an Amplify app. For example, `d6a88fjhifqlks` | `secret env` | **Yes** | N/A |
 | `BackendEnvARN` | The Amazon Resource Name (ARN) for a backend environment that is part of the Amplify app. If the Amplify App has no backend environment, don't set it. | `secret env` | **No** | N/A |
+| `EnvironmentVariables` | The environment variables for the branch. | `env` | **No** | N/A |
 | `GITHUB_TOKEN` | The `GITHUB_TOKEN`, should be supplied if a comment with the preview URL is to be posted on the PR.  GitHub automatically creates a `GITHUB_TOKEN` secret to use in your workflow. You can use it directly, see [About the GITHUB_TOKEN secret](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#about-the-github_token-secret) | `github env` | No | N/A |
 | `NewBackendEnvARN` | The Amazon Resource Name (ARN) for a backend environment that is part of an Amplify app. | `secret env` | No | N/A |
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,12 @@ else
   backend_env_arg=""
 fi
 
+if [[ ! -z "$EnvironmentVariables" ]] ; then
+  environment_variables_arg="--environment-variables=${EnvironmentVariables}"
+else
+  environment_variables_arg=""
+fi
+
 if [ -z "$BRANCH_NAME" ] ; then
   echo "You must provide branch name input parameter in order to deploy"
   exit 1
@@ -47,7 +53,7 @@ case $AMPLIFY_COMMAND in
 
   deploy)
     sh -c "aws amplify create-branch --app-id=${AmplifyAppId} --branch-name=$BRANCH_NAME  \
-              ${backend_env_arg} --region=${AWS_REGION}"
+              ${backend_env_arg} ${environment_variables_arg} --region=${AWS_REGION}"
 
     sleep 10
 


### PR DESCRIPTION
## Overview
Adds support for environment variables

## Changes
This PR implements support for environment variables so that we can target the correct SSM path when the deployment runs on AWS Amplify. 

The problem I've found is that I would like to reuse secrets from my develop branch when I create and deploy another branch. I use these secrets to authenticate with a package manager (JFrog), as an example I would see the following within the cloning the repo step:

```bash
---- Setting Up SSM Secrets ----
2023-04-10T22:27:21.468Z [INFO]: SSM params {"Path":"/amplify/{APP_ID}/develop/","WithDecryption":true}
```

However when we deploy with a new branch (`feat-new-branch`) it use the branch name as defined below meaning that I don't get the secrets in order to authenticate with my package manager.

 ```bash
---- Setting Up SSM Secrets ----
2023-04-10T22:27:21.468Z [INFO]: SSM params {"Path":"/amplify/{APP_ID}/feat-new-branch/","WithDecryption":true}
```

After some [digging](https://github.com/aws-amplify/amplify-hosting/issues/500) I've found that we need to set the `USER_BRANCH` environment variable for this to work correctly, I've confirmed this works by using the aws cli to replicate this end to end locally.

```bash
aws amplify create-branch \ 
  --app-id={APP_ID} \ 
  --region=ap-southeast-2 \
  --branch-name=feat/new-branch \
  --environment-variables=USER_BRANCH=develop
```

This change will solve my problem and also improve the capabilities of this action by allowing users to set any branch specific environment variables they desire 😄 